### PR TITLE
Improve EOS handling

### DIFF
--- a/create-project-async/eos-documents-example.json
+++ b/create-project-async/eos-documents-example.json
@@ -1,0 +1,10 @@
+[
+  {
+    "externalObjectStorageFileKey": "path/to/transcription.txt",
+    "fileName": "one.txt"
+  },
+  {
+    "externalObjectStorageFileKey": "path/to/document.pdf",
+    "fileName": "one.pdf"
+  }
+]

--- a/create-project-async/readme.md
+++ b/create-project-async/readme.md
@@ -9,8 +9,10 @@ python -m pip install -r src/requirements.txt
 
 ## Create Project
 
-### With local files, 
-Documents are located under `document/` folder
+### With Local Files
+
+Local files are located under `document/` folder.  
+Every file inside the directory will be uploaded to Datasaur as part of the project creation process.
 
 ```
 python api_client.py create_project \
@@ -20,19 +22,43 @@ python api_client.py create_project \
   --team_id TEAM_ID
 ```
 
-### With List of URLs
-
-Provide a JSON file with `documents_path`
-Example file available under `documents-example.json`
+### With Remote Files
 
 ```
 python api_client.py create_project \
   --base_url BASE_URL \
   --client_id CLIENT_ID \
   --client_secret CLIENT_SECRET \
-  --team_id TEAM_ID
+  --team_id TEAM_ID \
   --documents_path PATH_TO_DOCUMENTS_JSON
 ```
+
+Provide a JSON file with `--documents_path`.  
+Example file available under `documents-example.json`.
+
+```json
+[
+  {
+    "url": "<publicly accessible link to the file>",
+    "fileName": "<a unique filename>"
+  }
+]
+```
+
+If your team already have [External Object Storage](https://datasaurai.gitbook.io/datasaur/basics/workforce-management/external-object-storage) integration configured, the list of documents can be simplified. You can skip generating the URLs to each file, and just provide the path to the file instead.
+
+Example file available under `eos-documents-example.json`
+
+```json
+[
+  {
+    "externalObjectStorageFileKey": "path/to/file.txt",
+    "fileName": "<a unique filename>"
+  }
+]
+```
+
+The value of `fileName` does not have to match the actual file's name.
 
 ## Get Job Status
 

--- a/create-project-async/src/exceptions/invalid_options.py
+++ b/create-project-async/src/exceptions/invalid_options.py
@@ -1,0 +1,4 @@
+class InvalidOptions(Exception):
+    def __init__(self, message: str) -> None:
+        super().__init__(f"InvalidOptions: {message}")
+        self.message = message

--- a/create-project-async/src/project.py
+++ b/create-project-async/src/project.py
@@ -9,6 +9,7 @@ from src.helper import get_access_token, get_operations
 
 EXTERNAL_OBJECT_STORAGE_FILE_KEY = "externalObjectStorageFileKey"
 EXTERNAL_IMPORTABLE_URL = "externalImportableUrl"
+EXTERNAL_OBJECT_STORAGE_ID = "externalObjectStorageId"
 
 
 class Project:
@@ -85,7 +86,7 @@ class Project:
         # Set input.teamId
         operations["variables"]["input"]["teamId"] = team_id
         has_eos_id = operations["variables"]["input"].get(
-            EXTERNAL_OBJECT_STORAGE_FILE_KEY, False
+            EXTERNAL_OBJECT_STORAGE_ID, False
         )
 
         documents = []
@@ -105,12 +106,12 @@ class Project:
 
             if has_eos_id and file_key is None:
                 raise InvalidOptions(
-                    f"externalObjectStorageId needs {EXTERNAL_OBJECT_STORAGE_FILE_KEY} in documents array"
+                    f"{EXTERNAL_OBJECT_STORAGE_ID} needs {EXTERNAL_OBJECT_STORAGE_FILE_KEY} in documents array"
                 )
 
             if file_key and not file_url and not has_eos_id:
                 raise InvalidOptions(
-                    f"externalObjectStorageId is not provided, but document ${json.dumps(d)} only have {EXTERNAL_OBJECT_STORAGE_FILE_KEY}"
+                    f"{EXTERNAL_OBJECT_STORAGE_ID} is not provided, but document ${json.dumps(d)} only have {EXTERNAL_OBJECT_STORAGE_FILE_KEY}"
                 )
 
             documents.append(

--- a/create-project-async/src/project.py
+++ b/create-project-async/src/project.py
@@ -80,14 +80,17 @@ class Project:
             documents_list = json.load(reader)
 
         for d in documents_list:
-            file_url = d.get("url", None) or d.get("externalImportableUrl")
+            file_url = d.get("url", None) or d.get("externalImportableUrl", None)
             file_name = (
-                d.get("fileName", None) or d.get("filename", None) or d.get("name")
+                d.get("fileName", None) or d.get("filename", None)
             )
             file_key = d.get("externalObjectStorageFileKey", None)
 
             if has_eos_id and file_key is None:
                 raise InvalidOptions("externalObjectStorageId needs externalObjectStorageKey in documents array")
+            
+            if file_key and not file_url and not has_eos_id:
+                raise InvalidOptions("externalObjectStorageId is not provided, but document only have externalObjectStorageKey")
 
             documents.append(
                 {

--- a/create-project-async/src/project.py
+++ b/create-project-async/src/project.py
@@ -7,15 +7,27 @@ from src.exceptions.invalid_options import InvalidOptions
 from src.helper import get_access_token, get_operations
 
 
+EXTERNAL_OBJECT_STORAGE_FILE_KEY = "externalObjectStorageFileKey"
+EXTERNAL_IMPORTABLE_URL = "externalImportableUrl"
+
+
 class Project:
     @staticmethod
     def create(
         base_url, client_id, client_secret, team_id, operations_path, documents_path
     ):
         if os.path.isfile(documents_path):
-            print('received a file for documents_path, processing as list of documents...')
-            return Project.__handle_document_list(base_url, client_id, client_secret, team_id, operations_path, documents_path)
-        
+            print(
+                "received a file for documents_path, processing as list of documents..."
+            )
+            return Project.__handle_document_list(
+                base_url,
+                client_id,
+                client_secret,
+                team_id,
+                operations_path,
+                documents_path,
+            )
 
         url = f"{base_url}/graphql"
         access_token = get_access_token(base_url, client_id, client_secret)
@@ -72,32 +84,41 @@ class Project:
         operations = get_operations(operations_path)
         # Set input.teamId
         operations["variables"]["input"]["teamId"] = team_id
-        has_eos_id = operations["variables"]["input"].get("externalObjectStorageId", False)
+        has_eos_id = operations["variables"]["input"].get(
+            EXTERNAL_OBJECT_STORAGE_FILE_KEY, False
+        )
 
         documents = []
-        manual_keys = ["file", "fileName", "externalImportableUrl", "externalObjectStorageFileKey"]
+        manual_keys = [
+            "file",
+            "fileName",
+            EXTERNAL_IMPORTABLE_URL,
+            EXTERNAL_OBJECT_STORAGE_FILE_KEY,
+        ]
         with open(documents_list_path) as reader:
             documents_list = json.load(reader)
 
         for d in documents_list:
-            file_url = d.get("url", None) or d.get("externalImportableUrl", None)
-            file_name = (
-                d.get("fileName", None) or d.get("filename", None)
-            )
-            file_key = d.get("externalObjectStorageFileKey", None)
+            file_url = d.get("url", None) or d.get(EXTERNAL_IMPORTABLE_URL, None)
+            file_name = d.get("fileName", None) or d.get("filename", None)
+            file_key = d.get(EXTERNAL_OBJECT_STORAGE_FILE_KEY, None)
 
             if has_eos_id and file_key is None:
-                raise InvalidOptions("externalObjectStorageId needs externalObjectStorageKey in documents array")
-            
+                raise InvalidOptions(
+                    f"externalObjectStorageId needs {EXTERNAL_OBJECT_STORAGE_FILE_KEY} in documents array"
+                )
+
             if file_key and not file_url and not has_eos_id:
-                raise InvalidOptions("externalObjectStorageId is not provided, but document only have externalObjectStorageKey")
+                raise InvalidOptions(
+                    f"externalObjectStorageId is not provided, but document ${json.dumps(d)} only have {EXTERNAL_OBJECT_STORAGE_FILE_KEY}"
+                )
 
             documents.append(
                 {
-                    "externalImportableUrl": file_url,
+                    EXTERNAL_IMPORTABLE_URL: file_url,
                     "fileName": file_name,
                     "file": None,
-                    "externalObjectStorageFileKey": file_key
+                    EXTERNAL_OBJECT_STORAGE_FILE_KEY: file_key,
                 }
             )
 


### PR DESCRIPTION
Previously, we only handle the URLs field. This can lead to inconsistency when using EOS since we expect the file key instead of the URL. 

Here, we add support for file keys and raises exception when 
1. `externalObjectStorageId` is present, but `externalObjectStorageFileKey` is not used
2. `externalObjectStorageId` is not there, but the documents uses `externalObjectStorageFileKey`