### PR TITLE
#20283 Add options to generate credentials on create user

### DIFF
--- a/user-management/create_users.py
+++ b/user-management/create_users.py
@@ -14,7 +14,7 @@ from toolbox.get_access_token import get_access_token
 from toolbox.post_request import post_request
 
 
-def create_users(base_url, client_id, client_secret, input_file_path="./sample-files/create_users_input.csv", output_file_path="./sample-files/create_users_output.csv", email_verified=0):
+def create_users(base_url, client_id, client_secret, input_file_path="./sample-files/create_users_input.csv", output_file_path="./sample-files/create_users_output.csv", email_verified=0, generate_credentials=0):
     try:
         api_url = base_url + "/api/v1/users"
         access_token = get_access_token(base_url, client_id, client_secret)
@@ -30,15 +30,26 @@ def create_users(base_url, client_id, client_secret, input_file_path="./sample-f
                     "email": user[0],
                     "name": user[1],
                     "password": user[2],
-                    "emailVerified": email_verified
+                    "emailVerified": email_verified,
+                    "generateCredentials": generate_credentials
                 }
                 response = post_request(api_url, access_token, new_user)
 
                 if "json" in response.headers["content-type"]:
                     json_response = response.json()
                     if response.status_code == 200:
-                        user_id = json_response["data"]["id"]
-                        writer.writerow([user_id, new_user["email"], new_user["name"], new_user["password"]])
+                        output_data = [
+                            json_response["data"]["id"],
+                            new_user["email"],
+                            new_user["name"],
+                            new_user["password"]
+                        ]
+                        if generate_credentials:
+                            output_data.extend([
+                                json_response["data"]["clientId"],
+                                json_response["data"]["clientSecret"]
+                            ])
+                        writer.writerow(output_data)
                         pprint.pprint(json_response)
                     else:
                         raise Exception("{email} ERROR: {message}".format(email=new_user["email"], message=json_response["message"]))

--- a/user-management/readme.md
+++ b/user-management/readme.md
@@ -35,7 +35,8 @@ python create_users.py create_users \
     --client_secret <CLIENT_SECRET> \
     --input_file_path <INPUT_FILE_PATH> \
     --output_file_path <OUTPUT_FILE_PATH> \
-    --email_verified <EMAIL_VERIFIED>
+    --email_verified <EMAIL_VERIFIED> \
+    --generate_credentials <GENERATE_CREDENTIALS>
 ```
 
 **Options**
@@ -46,6 +47,7 @@ python create_users.py create_users \
 - `input_file_path` **(required)**: Path to the CSV file containing user data. Default is "./sample-files/create_users_input.csv".
 - `output_file_path` **(required)**: Path to the CSV file where the output data will be written. Default is "./output-files/create_users_output.csv".
 - `email_verified` **(optional)**: Flag indicating whether user emails are verified. Default is 0.
+- `generate_credentials` **(optional)**: Flag indicating whether the user's credentials will be generated. Default is 0.
 
 #### Input File Format
 
@@ -67,11 +69,13 @@ user2@email.com,UserName2,UserPa$$w0rd2
 
 The output file format is same with the input file format, but it have additional datas:
 1. **User's ID:** The ID of the created user.
+1. **User's Client ID (optional):** The client ID of the created user for authentication.
+1. **User's Client Secret (optional):** The client secret of the created user for authentication.
 
 Example CSV file content (located at [`sample-files/create_users_output.csv`](sample-files/create_users_output.csv)):
 
 ```csv
-1,user1@email.com,UserName1,UserPa$$w0rd1
-2,user2@email.com,UserName2,UserPa$$w0rd2
+1,user1@email.com,UserName1,UserPa$$w0rd1,clientId1,clientSecret1
+2,user2@email.com,UserName2,UserPa$$w0rd2,clientId2,clientSecret2
 ...
 ```

--- a/user-management/sample-files/create_users_output.csv
+++ b/user-management/sample-files/create_users_output.csv
@@ -1,2 +1,2 @@
-1,user1@email.com,UserName1,UserPa$$w0rd1
-2,user2@email.com,UserName2,UserPa$$w0rd2
+1,user1@email.com,UserName1,UserPa$$w0rd1,clientId1,clientSecret1
+2,user2@email.com,UserName2,UserPa$$w0rd2,clientId2,clientSecret2


### PR DESCRIPTION
Issue: https://github.com/vulcan-ai/vulcan/issues/20283

Task:
- [x] add param `generate_credentials`
- [x] output `client_id` and `client_secret` when `generate_credentials=1`
- [x] update readme
- [x] update output sample