### PR TITLE
#20992 Generate labelers' credential on the fly

### DIFF
--- a/apply-labels/.env.example
+++ b/apply-labels/.env.example
@@ -5,6 +5,7 @@ CLIENT_ID=
 CLIENT_SECRET=
 
 # Local / self-hosted where self-signed certificate is acceptable
+DISABLE_SSL_VERIFICATION=1
 OAUTHLIB_INSECURE_TRANSPORT=1
 
 CHUNK_SIZE=100

--- a/apply-labels/apply_labels.py
+++ b/apply-labels/apply_labels.py
@@ -4,14 +4,12 @@ import traceback
 
 import fire
 from dotenv import load_dotenv
-from helpers.users.load_labelers_and_populate_credentials import (
-    load_labelers_and_populate_credentials,
-)
 
 from src.entrypoint import check_login_and_teams
 from src.helpers import (
     GraphQLClient,
     create_labelers_file,
+    load_labelers_and_populate_credentials,
     populate_existing_labelers_file,
     read_config,
 )

--- a/apply-labels/apply_labels.py
+++ b/apply-labels/apply_labels.py
@@ -54,7 +54,6 @@ def apply_row_answers(
             )
             populate_existing_labelers_file(users_csv, labelers_file)
 
-        # data = load_jsonc(labelers_file)
         data = load_labelers_and_populate_credentials(
             labelers_file=labelers_file, config=config
         )

--- a/apply-labels/apply_labels.py
+++ b/apply-labels/apply_labels.py
@@ -4,12 +4,14 @@ import traceback
 
 import fire
 from dotenv import load_dotenv
+from helpers.users.load_labelers_and_populate_credentials import (
+    load_labelers_and_populate_credentials,
+)
 
 from src.entrypoint import check_login_and_teams
 from src.helpers import (
     GraphQLClient,
     create_labelers_file,
-    load_jsonc,
     populate_existing_labelers_file,
     read_config,
 )
@@ -54,18 +56,21 @@ def apply_row_answers(
             )
             populate_existing_labelers_file(users_csv, labelers_file)
 
-        data = load_jsonc(labelers_file)
+        # data = load_jsonc(labelers_file)
+        data = load_labelers_and_populate_credentials(
+            labelers_file=labelers_file, config=config
+        )
 
         Project(client=client).apply_row_answers(
             team_id=team_id,
             project_id=project_id,
-            labelers=data["labelers"],
+            labelers=data,
         )
         logging.info("apply_row_answers completed")
     except Exception as e:
         logging.error(e)
         traceback.print_exc()
-        SystemExit(e)
+        raise SystemExit(e)
 
 
 def convert_to_json(users_csv: str, labelers_file: str):

--- a/apply-labels/labelers.example.json
+++ b/apply-labels/labelers.example.json
@@ -8,9 +8,9 @@
     },
     {
       "email": "labeler2@email.tld",
-      "client_id": "<client_id>",
-      "client_secret": "<client_secret>",
       "documents": "data/labeler-2/"
+      // or, if you are running from a super-admin enabled account, 
+      // you can skip the client_id and client_secret part
     }
   ]
 }

--- a/apply-labels/readme.md
+++ b/apply-labels/readme.md
@@ -7,6 +7,7 @@ This folder focuses on workflows for row-labeling, where labelers' have applied 
 - [Table of contents](#table-of-contents)
 - [Prerequisites](#prerequisites)
 - [Quickstart](#quickstart)
+- [Setting-up the project](#setting-up-the-project)
 - [Commands](#commands)
   - [apply\_row\_answers](#apply_row_answers)
     - [Usage](#usage)
@@ -29,21 +30,38 @@ This folder focuses on workflows for row-labeling, where labelers' have applied 
 
 1. Ensure you have your Datasaur account ready, and that it can create / have access to a team workspace. **This will be your admin account.**
 2. Setup a Datasaur workspace and generate OAuth credentials from the admin account. For convenience, you can store the client id and secret as environment variables. The script will look for a `.env` file. We have provided a `.env.example` you can refer to. 
-3. Setup the labeler accounts. There are two possible approaches: 
+3. Setup your project and labelers' labeling data. For reference, we have provided a sample data under the `data/` folder. This will be explained in more details in the [next section](#setting-up-the-project). 
+4. Setup the labeler accounts. There are two possible approaches: 
     1. Using new, dedicated 'robot' accounts only for this workflow. This is suitable if you are doing a one-time migration from another platform, aggregating labels from multiple sources, or if you are reviewing inference results from models.
        - You'd setup the `labelers.json` file with the OAuth credentials of each labeler.
        - For your convenience, you could set-up multiple labeler accounts just for this workflow using the script from [`user_management`](../user-management/readme.md) folder.  
        **We recommend creating new accounts instead of using existing accounts as you'd be storing and using those OAuth credentials to apply the labels.**
        - Please check the convert_to_json commands for a quick way to convert the CSV result to a JSON file.  
-    2. Using existing accounts and generating OAuth Credentials on-the-fly. This is only available for self-hosted installation schemes. In this mode you don't need to provide labelers' credentials, just the `email` and `documents`. The credentials will be generated at the beginning of the script.  
+    2. Using existing accounts and generating OAuth Credentials on-the-fly. This is only available for self-hosted installation schemes. 
+        - Setup the `labelers.json` file. You can omit the  `client_id` and `client_secret` key.
         - As this requires a super-admin enabled account, it is only available for self-hosted installation schemes.
         - The script must be run with a super-admin enabled account, as it will attempt to regenerate the credentials using that account's OAuth credentials.
-        - Consequently, if this admin account is also to be assigned to the project, you need to provide the `client_id` and `client_secret` in the `labelers.json` file so that it does not get replaced. 
-4. Execute the script. It is configured to read the admin credentials from the `.env` file, and the labeler credentials from the specified json file.  
+        - Consequently, if this admin account is also to be assigned to the project, you need to provide the `client_id` and `client_secret` in the `labelers.json` file so that it does not get replaced.  
+5. Execute the script. It is configured to read the admin credentials from the `.env` file, and the labeler credentials from the specified json file.  
     Please refer to the `apply_row_answers` section below for detailed explanation. 
     ```console
     python apply_labels.py apply_row_answers --team_id TEAM_ID --project_id PROJECT_ID [--labelers_file labelers.json] [--verbose]
     ```
+
+## Setting-up the project
+
+1. Create a row-based project using *only the data columns*. Any columns that are supposed to be answered by labelers should be configured as questions instead. 
+    - Configure the questions accordingly. Provide them with unique labels, and take note of them. 
+    - Assign the project to the labelers.
+    - Please see `data/reference` for an example of a project data file.  
+2. Prepare the labelers' labeled data. This file should represent what labelers / models have answered. 
+    - Each document should have their own folder. Their work should be stored in CSV files inside that folder. `labelers.json` should point to these folder. 
+    - See `data/labeler-1` and `data/labeler-2` for an example. 
+    - The first row of the files will be considered as headers. 
+    - The script will use these headers to match the column to the question in the project. Any extra columns will raised as a warning, but it won't fail the script. 
+    - Each file in these folder should match with the documents you have uploaded to Datasaur when creating the project. 
+
+Once the project is created, and the labeling data is prepared, you can continue configuring the script. 
 
 ## Commands
 
@@ -113,7 +131,7 @@ python apply_labels.py convert_to_json --users_csv <filepath> --labelers_file <f
 ```
 
 - `users_csv` (str): The path to the CSV file containing the users' information. This should be the output you get after running the command from the [`user_management`](../user-management/readme.md) folder.
-- `labelers_file` (str): Path to a JSON file we'll write.  
+- `labelers_file` (str): Path to a JSON file the script will write.  
     If the file exists, the script will populate the client_id & client_secret of the users that don't have them yet, and add missing users to the JSON file with empty documents assignment.  
     If it doesn't exist, the script will create the file and populate it with the users' information.  
 

--- a/apply-labels/readme.md
+++ b/apply-labels/readme.md
@@ -60,7 +60,8 @@ Replace `<team-id>`, and `<project-id>` with your actual values. These values ar
 Command parameters: 
 - `team_id` (str): The ID of the team.
 - `project_id` (str): The ID of the project. The project's ID is also visible in the URL. 
-- `labelers_file` (str, optional): Path to the JSON file that contains the labelers. Defaults to "labelers.json".
+- `labelers_file` (str, optional): Path to the JSON file that contains the labelers. Defaults to "labelers.json".  
+      ***SuperAdmin mode***: If you are running the script from a super-admin enabled-account, you can skip providing client_id and client_secret for the labelers. The script will attempt to fetch the labelers' credential from the user management API.
 - `users_csv` (str, optional): Path to a CSV file containing users info. See [user_management readme](../user-management/readme.md) for structure. If omitted, script will only read from labelers_file.
 - `verbose` (bool, optional): Whether to output verbose messages. Defaults to False.
 
@@ -108,7 +109,7 @@ python apply_labels.py convert_to_json --users_csv <filepath> --labelers_file <f
 - `users_csv` (str): The path to the CSV file containing the users' information. This should be the output you get after running the command from the [`user_management`](../user-management/readme.md) folder.
 - `labelers_file` (str): Path to a JSON file we'll write.  
     If the file exists, the script will populate the client_id & client_secret of the users that don't have them yet, and add missing users to the JSON file with empty documents assignment.  
-    If it doesn't exist, the script will create the file and populate it with the users' information.
+    If it doesn't exist, the script will create the file and populate it with the users' information.  
 
 ### check_teams
 

--- a/apply-labels/readme.md
+++ b/apply-labels/readme.md
@@ -30,18 +30,19 @@ This folder focuses on workflows for row-labeling, where labelers' have applied 
 
 1. Ensure you have your Datasaur account ready, and that it can create / have access to a team workspace. **This will be your admin account.**
 2. Setup a Datasaur workspace and generate OAuth credentials from the admin account. For convenience, you can store the client id and secret as environment variables. The script will look for a `.env` file. We have provided a `.env.example` you can refer to. 
-3. Setup your project and labelers' labeling data. For reference, we have provided a sample data under the `data/` folder. This will be explained in more details in the [next section](#setting-up-the-project). 
-4. Setup the labeler accounts. There are two possible approaches: 
+3. Setup the labeler accounts. There are two possible approaches: 
     1. Using new, dedicated 'robot' accounts only for this workflow. This is suitable if you are doing a one-time migration from another platform, aggregating labels from multiple sources, or if you are reviewing inference results from models.
        - You'd setup the `labelers.json` file with the OAuth credentials of each labeler.
        - For your convenience, you could set-up multiple labeler accounts just for this workflow using the script from [`user_management`](../user-management/readme.md) folder.  
        **We recommend creating new accounts instead of using existing accounts as you'd be storing and using those OAuth credentials to apply the labels.**
        - Please check the convert_to_json commands for a quick way to convert the CSV result to a JSON file.  
     2. Using existing accounts and generating OAuth Credentials on-the-fly. This is only available for self-hosted installation schemes. 
-        - Setup the `labelers.json` file. You can omit the  `client_id` and `client_secret` key.
+        - Setup the `labelers.json` file. You can omit the  `client_id` and `client_secret` key.  
+        The `documents` key should point to a folder containing the labelers' work. See the next [section](#setting-up-the-project) and our examples in `data/labeler-1`, `data/labeler-2` and `labelers.example.json` for reference 
         - As this requires a super-admin enabled account, it is only available for self-hosted installation schemes.
         - The script must be run with a super-admin enabled account, as it will attempt to regenerate the credentials using that account's OAuth credentials.
         - Consequently, if this admin account is also to be assigned to the project, you need to provide the `client_id` and `client_secret` in the `labelers.json` file so that it does not get replaced.  
+4. Setup your project and labelers' labeling data. For reference, we have provided a sample data under the `data/` folder. This will be explained in more details in the [next section](#setting-up-the-project). 
 5. Execute the script. It is configured to read the admin credentials from the `.env` file, and the labeler credentials from the specified json file.  
     Please refer to the `apply_row_answers` section below for detailed explanation. 
     ```console
@@ -55,13 +56,13 @@ This folder focuses on workflows for row-labeling, where labelers' have applied 
     - Assign the project to the labelers.
     - Please see `data/reference` for an example of a project data file.  
 2. Prepare the labelers' labeled data. This file should represent what labelers / models have answered. 
-    - Each document should have their own folder. Their work should be stored in CSV files inside that folder. `labelers.json` should point to these folder. 
+    - Each labeler should have their own folder and their work should be stored as CSV files inside that folder.
     - See `data/labeler-1` and `data/labeler-2` for an example. 
     - The first row of the files will be considered as headers. 
     - The script will use these headers to match the column to the question in the project. Any extra columns will raised as a warning, but it won't fail the script. 
     - Each file in these folder should match with the documents you have uploaded to Datasaur when creating the project. 
 
-Once the project is created, and the labeling data is prepared, you can continue configuring the script. 
+Once the project is created, and the labeling data is prepared, you can continue with configuring and executing the script. 
 
 ## Commands
 

--- a/apply-labels/readme.md
+++ b/apply-labels/readme.md
@@ -29,10 +29,16 @@ This folder focuses on workflows for row-labeling, where labelers' have applied 
 
 1. Ensure you have your Datasaur account ready, and that it can create / have access to a team workspace. **This will be your admin account.**
 2. Setup a Datasaur workspace and generate OAuth credentials from the admin account. For convenience, you can store the client id and secret as environment variables. The script will look for a `.env` file. We have provided a `.env.example` you can refer to. 
-3. Create and invite the labeler accounts you will be applying labels as. For each one, generate OAuth credentials and save the client id and secret. This time, not in the `.env` file, but in a `labelers.json` file. We have provided an example `labelers.json.example` you can refer to. We'll be using the [pyjson5](https://pypi.org/project/pyjson5/) library to parse this file, so you can use comments inside.
-    - For your convenience, you could set-up multiple labeler accounts just for this workflow using the script from [`user_management`](../user-management/readme.md) folder.  
-    **We recommend creating new accounts instead of using existing accounts as you'd be storing and using those OAuth credentials to apply the labels.**
-    - Please check the convert_to_json commands for a quick way to convert the CSV result to a JSON file.
+3. Setup the labeler accounts. There are two possible approaches: 
+    1. Using new, dedicated 'robot' accounts only for this workflow. This is suitable if you are doing a one-time migration from another platform, aggregating labels from multiple sources, or if you are reviewing inference results from models.
+       - You'd setup the `labelers.json` file with the OAuth credentials of each labeler.
+       - For your convenience, you could set-up multiple labeler accounts just for this workflow using the script from [`user_management`](../user-management/readme.md) folder.  
+       **We recommend creating new accounts instead of using existing accounts as you'd be storing and using those OAuth credentials to apply the labels.**
+       - Please check the convert_to_json commands for a quick way to convert the CSV result to a JSON file.  
+    2. Using existing accounts and generating OAuth Credentials on-the-fly. This is only available for self-hosted installation schemes. In this mode you don't need to provide labelers' credentials, just the `email` and `documents`. The credentials will be generated at the beginning of the script.  
+        - As this requires a super-admin enabled account, it is only available for self-hosted installation schemes.
+        - The script must be run with a super-admin enabled account, as it will attempt to regenerate the credentials using that account's OAuth credentials.
+        - Consequently, if this admin account is also to be assigned to the project, you need to provide the `client_id` and `client_secret` in the `labelers.json` file so that it does not get replaced. 
 4. Execute the script. It is configured to read the admin credentials from the `.env` file, and the labeler credentials from the specified json file.  
     Please refer to the `apply_row_answers` section below for detailed explanation. 
     ```console

--- a/apply-labels/src/helpers/__init__.py
+++ b/apply-labels/src/helpers/__init__.py
@@ -1,11 +1,13 @@
 from os import getenv
 from os import path as ospath
 
+from .admin_rest_client import *
 from .get_operations import *
 from .graphql_client import *
 from .load_jsonc import *
 from .loggable import *
 from .users.create_labelers_file import *
+from .users.load_labelers_and_populate_credentials import *
 from .users.populate_existing_labelers_file import *
 
 

--- a/apply-labels/src/helpers/admin_rest_client.py
+++ b/apply-labels/src/helpers/admin_rest_client.py
@@ -1,4 +1,5 @@
 import time
+from os import getenv
 from urllib.parse import urljoin
 
 import requests
@@ -31,6 +32,7 @@ class AdminRESTClient:
             url=urljoin(self.url, path),
             json=json_data,
             headers=headers,
+            verify=False if getenv("DISABLE_SSL_VERIFICATION") else True,
         )
 
     def __should_set_self_token(self) -> bool:

--- a/apply-labels/src/helpers/admin_rest_client.py
+++ b/apply-labels/src/helpers/admin_rest_client.py
@@ -1,9 +1,10 @@
 import time
 from urllib.parse import urljoin
-import requests
-from requests_oauthlib import OAuth2
 
-from helpers import get_access_token
+import requests
+
+from .get_access_token import get_access_token
+from .loggable import loggable_with_args
 
 
 class AdminRESTClient:
@@ -15,6 +16,7 @@ class AdminRESTClient:
         self.client_secret = admin_client_secret
         self.token = None
 
+    @loggable_with_args
     def call_rest(self, path: str, data, method="POST"):
         if self.__should_set_self_token():
             self.token = get_access_token(self.client_id, self.client_secret, self.url)

--- a/apply-labels/src/helpers/admin_rest_client.py
+++ b/apply-labels/src/helpers/admin_rest_client.py
@@ -17,7 +17,7 @@ class AdminRESTClient:
         self.token = None
 
     @loggable_with_args
-    def call_rest(self, path: str, data, method="POST"):
+    def call_rest(self, path: str, json_data, method="POST"):
         if self.__should_set_self_token():
             self.token = get_access_token(self.client_id, self.client_secret, self.url)
 
@@ -29,7 +29,7 @@ class AdminRESTClient:
         return requests.request(
             method=method,
             url=urljoin(self.url, path),
-            data=data,
+            json=json_data,
             headers=headers,
         )
 

--- a/apply-labels/src/helpers/call_graphql.py
+++ b/apply-labels/src/helpers/call_graphql.py
@@ -1,4 +1,5 @@
 import logging
+from os import getenv
 
 import requests
 from termcolor import colored
@@ -13,7 +14,12 @@ def call_graphql(url: str, headers: dict[str, str], data):
     else:
         logging.debug(colored(f"{data=}", "grey"))
 
-    response = requests.post(decorated_url, headers=headers, data=data)
+    response = requests.post(
+        decorated_url,
+        headers=headers,
+        data=data,
+        verify=False if getenv("DISABLE_SSL_VERIFICATION") else True,
+    )
 
     if response.status_code != 200:
         raise ValueError(f"GraphQL request failed: {response.text}")

--- a/apply-labels/src/helpers/get_access_token.py
+++ b/apply-labels/src/helpers/get_access_token.py
@@ -1,4 +1,5 @@
 import logging
+from os import getenv
 
 from oauthlib.oauth2 import BackendApplicationClient
 from requests_oauthlib import OAuth2Session
@@ -17,6 +18,7 @@ def get_access_token(
         token_url=f"{base_url}/api/oauth/token",
         client_id=client_id,
         client_secret=client_secret,
+        verify=False if getenv("DISABLE_SSL_VERIFICATION") else True,
     )
 
     logging.debug(colored(f"{token=}", "grey"))

--- a/apply-labels/src/helpers/graphql_client.py
+++ b/apply-labels/src/helpers/graphql_client.py
@@ -38,7 +38,7 @@ class GraphQLClient:
         assert token is not None
         headers = {
             "Authorization": f"Bearer {token}",
-            "User-Agent": "api-client/apply-labels",
+            "User-Agent": "api-client/apply-labels GraphQLClient",
         }
         return call_graphql(f"{self.url}/graphql", headers, data=data)
 

--- a/apply-labels/src/helpers/rest_client.py
+++ b/apply-labels/src/helpers/rest_client.py
@@ -1,0 +1,35 @@
+import time
+from urllib.parse import urljoin
+import requests
+from requests_oauthlib import OAuth2
+
+from helpers import get_access_token
+
+
+class AdminRESTClient:
+    def __init__(
+        self, base_url: str, admin_client_id: str, admin_client_secret: str
+    ) -> None:
+        self.url = base_url
+        self.client_id = admin_client_id
+        self.client_secret = admin_client_secret
+        self.token = None
+
+    def call_rest(self, path: str, data, method="POST"):
+        if self.__should_set_self_token():
+            self.token = get_access_token(self.client_id, self.client_secret, self.url)
+
+        assert self.token is not None
+        headers = {
+            "Authorization": f'Bearer {self.token["access_token"]}',
+            "User-Agent": "api-client/apply-labels AdminRESTClient",
+        }
+        return requests.request(
+            method=method,
+            url=urljoin(self.url, path),
+            data=data,
+            headers=headers,
+        )
+
+    def __should_set_self_token(self) -> bool:
+        return self.token is None or self.token["expires_at"] < time.time()

--- a/apply-labels/src/helpers/users/load_labelers_and_populate_credentials.py
+++ b/apply-labels/src/helpers/users/load_labelers_and_populate_credentials.py
@@ -1,0 +1,36 @@
+import logging
+from helpers.rest_client import AdminRESTClient
+from models import LabelerAssignment, User
+from src.helpers import load_jsonc
+from user.oauth import UserOAuthCredentials
+
+
+def load_labelers_and_populate_credentials(labelers_file: str, config: dict):
+    data_from_file = load_jsonc(labelers_file)
+    labeler_with_credentials = []
+    rest_client = AdminRESTClient(
+        base_url=config["base_url"],
+        admin_client_id=config["client_id"],
+        admin_client_secret=config["client_secret"],
+    )
+
+    for labeler in data_from_file["labelers"]:
+        if (labeler["client_id"] is None) or (labeler["client_secret"] is None):
+            logging.warning(
+                f"missing client_id or client_secret for {labeler['email']}, generating new credential for them"
+            )
+            credential = UserOAuthCredentials(
+                admin_client=rest_client
+            ).generate_oauth_credentials(email=labeler["email"])
+
+            labeler_with_credentials.append(
+                {
+                    **labeler,
+                    "client_id": credential["client_id"],
+                    "client_secret": credential["client_secret"],
+                }
+            )
+        else:
+            labeler_with_credentials.append(labeler)
+
+    return labeler_with_credentials

--- a/apply-labels/src/helpers/users/load_labelers_and_populate_credentials.py
+++ b/apply-labels/src/helpers/users/load_labelers_and_populate_credentials.py
@@ -10,15 +10,15 @@ from ..loggable import loggable_with_args
 @loggable_with_args
 def load_labelers_and_populate_credentials(labelers_file: str, config: dict):
     data_from_file = load_jsonc(labelers_file)
-    labeler_with_credentials = []
+
     rest_client = AdminRESTClient(
         base_url=config["base_url"],
         admin_client_id=config["client_id"],
         admin_client_secret=config["client_secret"],
     )
 
+    labelers_with_credentials = []
     labelers_need_credentials = []
-
     for labeler in data_from_file["labelers"]:
         labeler_client_id = labeler.get("client_id", None)
         labeler_client_secret = labeler.get("client_secret", None)
@@ -28,7 +28,7 @@ def load_labelers_and_populate_credentials(labelers_file: str, config: dict):
             )
             labelers_need_credentials.append(labeler)
         else:
-            labeler_with_credentials.append(labeler)
+            labelers_with_credentials.append(labeler)
 
     if (len(labelers_need_credentials)) > 0:
         credentials = UserOAuthCredentials(rest_client).generate_oauth_credentials(
@@ -51,14 +51,14 @@ def load_labelers_and_populate_credentials(labelers_file: str, config: dict):
                 labeler["client_secret"] = credentials_by_email[labeler["email"]][
                     "client_secret"
                 ]
-                labeler_with_credentials.append(labeler)
+                labelers_with_credentials.append(labeler)
             except Exception as e:
                 logging.error(
                     f"failed to generate credential for {labeler['email']}, omitting them from the list of labelers",
                     e,
                 )
 
-    return labeler_with_credentials
+    return labelers_with_credentials
 
 
 def is_none_or_empty(*args):

--- a/apply-labels/src/helpers/users/load_labelers_and_populate_credentials.py
+++ b/apply-labels/src/helpers/users/load_labelers_and_populate_credentials.py
@@ -20,9 +20,9 @@ def load_labelers_and_populate_credentials(labelers_file: str, config: dict):
     labelers_need_credentials = []
 
     for labeler in data_from_file["labelers"]:
-        if (labeler.get("client_id", None) is None) or (
-            labeler.get("client_secret", None) is None
-        ):
+        labeler_client_id = labeler.get("client_id", None)
+        labeler_client_secret = labeler.get("client_secret", None)
+        if is_none_or_empty(labeler_client_id, labeler_client_secret):
             logging.warning(
                 f"missing client_id or client_secret for {labeler['email']}, generating new credential for them"
             )
@@ -59,3 +59,7 @@ def load_labelers_and_populate_credentials(labelers_file: str, config: dict):
                 )
 
     return labeler_with_credentials
+
+
+def is_none_or_empty(*args):
+    return any(arg is None or arg == "" for arg in args)

--- a/apply-labels/src/helpers/users/load_labelers_and_populate_credentials.py
+++ b/apply-labels/src/helpers/users/load_labelers_and_populate_credentials.py
@@ -1,6 +1,5 @@
 import logging
-from helpers.rest_client import AdminRESTClient
-from models import LabelerAssignment, User
+from src.helpers.rest_client import AdminRESTClient
 from src.helpers import load_jsonc
 from user.oauth import UserOAuthCredentials
 
@@ -14,23 +13,40 @@ def load_labelers_and_populate_credentials(labelers_file: str, config: dict):
         admin_client_secret=config["client_secret"],
     )
 
+    labelers_need_credentials = []
+
     for labeler in data_from_file["labelers"]:
         if (labeler["client_id"] is None) or (labeler["client_secret"] is None):
             logging.warning(
                 f"missing client_id or client_secret for {labeler['email']}, generating new credential for them"
             )
-            credential = UserOAuthCredentials(
-                admin_client=rest_client
-            ).generate_oauth_credentials(email=labeler["email"])
-
-            labeler_with_credentials.append(
-                {
-                    **labeler,
-                    "client_id": credential["client_id"],
-                    "client_secret": credential["client_secret"],
-                }
-            )
+            labelers_need_credentials.append(labeler)
         else:
             labeler_with_credentials.append(labeler)
+
+    if (len(labelers_need_credentials)) > 0:
+        credentials = UserOAuthCredentials(rest_client).generate_oauth_credentials(
+            emails=[labeler["email"] for labeler in labelers_need_credentials]
+        )
+
+        map_of_credentials = {
+            credential["email"]: {
+                "client_id": credential["client_id"],
+                "client_secret": credential["client_secret"],
+            }
+            for credential in credentials
+        }
+
+        for labeler in labelers_need_credentials:
+            try:
+                labeler["client_id"] = map_of_credentials[labeler["email"]]["client_id"]
+                labeler["client_secret"] = map_of_credentials[labeler["email"]][
+                    "client_secret"
+                ]
+                labeler_with_credentials.append(labeler)
+            except Exception as e:
+                logging.error(
+                    f"failed to generate credential for {labeler['email']}, {e}"
+                )
 
     return labeler_with_credentials

--- a/apply-labels/src/project/project.py
+++ b/apply-labels/src/project/project.py
@@ -1,6 +1,5 @@
 import logging
 from json import dumps
-from time import sleep
 
 from src.helpers import GraphQLClient, get_operations, loggable
 
@@ -33,7 +32,6 @@ class Project:
             client=self.client,
             project=project,
         ).fetch(labeler=labeler)
-        sleep(5)
         labeler_client = GraphQLClient(
             base_url=self.client.url,
             client_id=labeler["client_id"],

--- a/apply-labels/src/project/project.py
+++ b/apply-labels/src/project/project.py
@@ -1,5 +1,4 @@
 import logging
-from collections import namedtuple
 from json import dumps
 
 from src.helpers import GraphQLClient, get_operations, loggable

--- a/apply-labels/src/project/project.py
+++ b/apply-labels/src/project/project.py
@@ -1,5 +1,6 @@
 import logging
 from json import dumps
+from time import sleep
 
 from src.helpers import GraphQLClient, get_operations, loggable
 
@@ -22,7 +23,6 @@ class Project:
             kinds=["ROW_BASED"],
         )
         self.replicate_cabinet(project=project, labelers=labelers)
-
         for labeler in labelers:
             logging.debug(f"applying row answers for {labeler['email']}")
             self.apply_row_answer_for_labeler(project, labeler)
@@ -33,6 +33,7 @@ class Project:
             client=self.client,
             project=project,
         ).fetch(labeler=labeler)
+        sleep(5)
         labeler_client = GraphQLClient(
             base_url=self.client.url,
             client_id=labeler["client_id"],

--- a/apply-labels/src/project/row_document.py
+++ b/apply-labels/src/project/row_document.py
@@ -2,6 +2,7 @@ import logging
 import os
 from csv import reader
 from json import dumps
+from time import sleep
 from typing import Any
 
 from termcolor import colored
@@ -91,6 +92,7 @@ class RowProjectDocument:
                 question_set=question_set,
                 starting_index=i * CHUNK_SIZE,
             )
+            sleep(0.5)
 
     @loggable_debug
     def __apply_answer_per_document(

--- a/apply-labels/src/user/oauth.py
+++ b/apply-labels/src/user/oauth.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from pprint import pprint
 from src.helpers.rest_client import AdminRESTClient
 
@@ -7,15 +8,24 @@ class UserOAuthCredentials:
         self.client = admin_client
         self.__check_access()
 
-    def generate_oauth_credentials(self, email: str):
-        return self.client.call_rest(
+    def generate_oauth_credentials(self, emails: list[str]):
+        response = self.client.call_rest(
             path="/api/v1/users/oauth",
             method="POST",
-            data={"email": email},
-        ).json()
+            data={"emails": emails},
+        )
+
+        if response.status_code == HTTPStatus.OK:
+            return response.json()
+
+        raise Exception(
+            "failed to generate OAuth credentials",
+            {"status": response.status_code, "text": response.text},
+        )
 
     def __check_access(self):
         try:
             self.client.call_rest(path="/api/v1/users", method="GET", data={})
         except Exception as e:
             pprint(e)
+            raise e

--- a/apply-labels/src/user/oauth.py
+++ b/apply-labels/src/user/oauth.py
@@ -1,0 +1,21 @@
+from pprint import pprint
+from src.helpers.rest_client import AdminRESTClient
+
+
+class UserOAuthCredentials:
+    def __init__(self, admin_client: AdminRESTClient):
+        self.client = admin_client
+        self.__check_access()
+
+    def generate_oauth_credentials(self, email: str):
+        return self.client.call_rest(
+            path="/api/v1/users/oauth",
+            method="POST",
+            data={"email": email},
+        ).json()
+
+    def __check_access(self):
+        try:
+            self.client.call_rest(path="/api/v1/users", method="GET", data={})
+        except Exception as e:
+            pprint(e)

--- a/apply-labels/src/user/oauth.py
+++ b/apply-labels/src/user/oauth.py
@@ -15,7 +15,7 @@ class UserOAuthCredentials:
         response = self.client.call_rest(
             path=f"{_USER_PREFIX}/oauth",
             method="POST",
-            data={"emails": emails},
+            json_data={"emails": emails},
         )
 
         if response.status_code == HTTPStatus.OK:
@@ -26,8 +26,9 @@ class UserOAuthCredentials:
             {"status": response.status_code, "text": response.text},
         )
 
+    @loggable_debug
     def __check_access(self):
-        response = self.client.call_rest(path=_USER_PREFIX, method="GET", data={})
+        response = self.client.call_rest(path=_USER_PREFIX, method="GET", json_data={})
         if response.status_code == HTTPStatus.OK:
             return True
         else:


### PR DESCRIPTION
# Changes

- after reading labelers.json file, check for client_id and client_secret values
    - if there are missing values, try to generate them
        - exits if failed to genereate
        - if succeeded in generating the credentials, save them _in memory only_, then proceed to the next steps (applying labels) 
    - if there are no missing values, proceed to the next steps (applying labels)