### PR TITLE
Fix: datasaur_schemas_to_coco failed to run on Windows.

### DIFF
--- a/bounding-boxes/src/datasaur_schemas_to_coco.py
+++ b/bounding-boxes/src/datasaur_schemas_to_coco.py
@@ -204,9 +204,13 @@ def coco_categories_from_datasaur_schema(schema: dict) -> list[COCOCategory]:
 
 def coco_images_from_datasaur_schema(id: int, schema: dict) -> COCOImage:
     width, height = 0, 0
-    if schema["data"]["pages"] is not None and len(schema["data"]["pages"]) >= 1:
-        width = schema["data"]["pages"][0]["pageWidth"]
-        height = schema["data"]["pages"][0]["pageHeight"]
+    try:
+        if schema["data"]["pages"] is not None and len(schema["data"]["pages"]) >= 1:
+            width = schema["data"]["pages"][0]["pageWidth"]
+            height = schema["data"]["pages"][0]["pageHeight"]
+    except KeyError:
+        # some older Bounding Box projects may not have pageWidth / pageHeight populated
+        pass
 
     return COCOImage(
         id=id,

--- a/bounding-boxes/src/datasaur_schemas_to_coco.py
+++ b/bounding-boxes/src/datasaur_schemas_to_coco.py
@@ -11,7 +11,14 @@ import tempfile
 
 
 from common.logger import log as _log
-from formats.coco import COCO, COCOAnnotation, COCOCategory, COCOImage
+from formats.coco import (
+    COCO,
+    COCOAnnotation,
+    COCOCategory,
+    COCOImage,
+    COCOLicense,
+    COCOInfo,
+)
 
 
 def log(message, level=logging.DEBUG, **kwargs):
@@ -51,6 +58,9 @@ def datasaur_schemas_to_coco(
             "year": 2024,
         }
 
+    coco_info = COCOInfo(**info)
+    coco_licenses = [COCOLicense(**l) for l in licenses]
+
     schemas = [s for s in schema_objects]
 
     # assuming all DatasaurSchema are from the same project,
@@ -70,8 +80,8 @@ def datasaur_schemas_to_coco(
 
     return asdict(
         COCO(
-            info=info,
-            licenses=licenses,
+            info=coco_info,
+            licenses=coco_licenses,
             categories=categories,
             images=images,
             annotations=annotations,

--- a/bounding-boxes/src/datasaur_schemas_to_coco.py
+++ b/bounding-boxes/src/datasaur_schemas_to_coco.py
@@ -248,18 +248,19 @@ def unzip_export_result(export_zip: str, dest: str) -> list[str]:
     retval: list[str] = []
     log("unzipping export result to temp directory", export_zip=export_zip)
     with ZipFile(export_zip, "r") as zf:
-        project_dir: str | None = None
+        project_dirs: list[str] = []
+
         for zippath in ZipPath(zf).iterdir():
             if zippath.is_dir():
-                project_dir = zippath.name
-                break
-        if not (project_dir):
+                project_dirs.append(zippath.name)
+
+        if len(project_dirs) == 0:
             log("no project dir found in export result", level=logging.ERROR)
             raise Exception("no project dir found")
 
-        log("project_dir", project_dir=project_dir)
+        prefixes = [f"{project_dir}/REVIEW" for project_dir in project_dirs]
         for zip_content in zf.infolist():
-            if not zip_content.filename.startswith(os.path.join(project_dir, "REVIEW")):
+            if not any(zip_content.filename.startswith(prefix) for prefix in prefixes):
                 continue
 
             if zip_content.is_dir():

--- a/bounding-boxes/src/datasaur_schemas_to_coco.py
+++ b/bounding-boxes/src/datasaur_schemas_to_coco.py
@@ -111,12 +111,8 @@ def main() -> None:
     logging.basicConfig(level=args.log_level, format="%(message)s")
 
     export_zip = os.path.abspath(args.zip_filepath)
-    temp_destination = tempfile.mkdtemp()
-    os.makedirs(temp_destination, exist_ok=True)
-
-    log("creating temp directory", directory=temp_destination)
-
-    try:
+    with tempfile.TemporaryDirectory() as temp_destination:
+        log("using temp directory", directory=temp_destination)
         outfile = os.path.abspath(args.outfile)
         outdir = os.path.dirname(outfile)
         os.makedirs(outdir, exist_ok=True)
@@ -142,8 +138,6 @@ def main() -> None:
             json.dump(coco, wf, indent=2)
 
         log("cleaning up temp directory", directory=temp_destination)
-    finally:
-        rmtree(temp_destination)
 
 
 def coco_annots_from_datasaur_schemas(

--- a/bounding-boxes/src/datasaur_schemas_to_coco.py
+++ b/bounding-boxes/src/datasaur_schemas_to_coco.py
@@ -164,9 +164,10 @@ def coco_annots_from_datasaur_schemas(
                     bbox_label["bboxLabelClassId"], None
                 )
 
-                for key, value in answers.items():
-                    question_label = questions[key]["label"]
-                    attributes[question_label] = value
+                if questions:
+                    for key, value in answers.items():
+                        question_label = questions[key]["label"]
+                        attributes[question_label] = value
 
             annots.append(
                 COCOAnnotation(


### PR DESCRIPTION
## Root cause

```py
if not zip_content.filename.startswith(os.path.join(project_dir, "REVIEW")):
```

using `os.path.join` here causes Python to append `\\`, while Datasaur generates the zipfiles with `/`

## Changes

1. Replace os.path.join with `/` 
2. `None` typing errors: add conditional checks
3. Add multi-project handling -- iterates through the whole zipfile instead of breaking out after the first valid project entry
    Caveat: expect all project to have the same labelset. If they don't, the script will error-out in the middle of extracting. 
4. Uses tempfile.TemporaryDirectory instead of manually creating a new `./temp/` directory
