### PR TITLE
#25711 Enhance bbox_label_class attributes generation

### DIFF
--- a/bounding-boxes/samples/custom-label-set.json
+++ b/bounding-boxes/samples/custom-label-set.json
@@ -25,7 +25,7 @@
           }
         },
         {
-          "id": 1,
+          "id": 0,
           "label": "label-2",
           "type": "TEXT",
           "required": false,

--- a/bounding-boxes/samples/custom-label-set.json
+++ b/bounding-boxes/samples/custom-label-set.json
@@ -6,6 +6,7 @@
       "questions": [
         {
           "id": 0,
+          "internalId": 123,
           "label": "bio_tag",
           "required": false,
           "type": "DROPDOWN",
@@ -26,6 +27,7 @@
         },
         {
           "id": 0,
+          "internalId": 123,
           "label": "label-2",
           "type": "TEXT",
           "required": false,

--- a/bounding-boxes/src/coco_to_datasaur_schemas.py
+++ b/bounding-boxes/src/coco_to_datasaur_schemas.py
@@ -169,7 +169,7 @@ def bbox_label_classes_from_coco(
 
         questions = [
             DSBBoxLabelClassQuestions(
-                id=q.get("id", index),
+                id=index,
                 label=q.get("label", f"Question {index}"),
                 config=QuestionConfig(
                     multiline=q.get("config", {}).get("multiline", None),


### PR DESCRIPTION
## Changes: 

- Previously, we prioritized any id we found in the JSON provided by users. This can lead to duplicate id error if users erroneously set the same id multiple times. 
- Now we rely on array indices, so attributes' id should always be unique

## How-to-test?

See that there's a duplicate `id` and `internalId` in `custom-label-set.json`
run the script
```bash
$ python src/coco_to_datasaur_schemas.py --custom-labelset samples/custom-label-set.json samples/COCO.json
```
Should create a new `sample.json` file under `outdir/`

Try to create a Datasaur project using any media `sample.jpg` / `sample.pdf`

It should pass Preview step, and be created into a project. 